### PR TITLE
feat: don't replace functions when text length would increase

### DIFF
--- a/package.json
+++ b/package.json
@@ -36,6 +36,9 @@
 	"lint-staged": {
 		"*": "prettier --ignore-unknown --write"
 	},
+	"dependencies": {
+		"cached-factory": "^0.0.2"
+	},
 	"devDependencies": {
 		"@prettier/sync": "^0.5.0",
 		"@release-it/conventional-changelog": "^8.0.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -7,6 +7,10 @@ settings:
 importers:
 
   .:
+    dependencies:
+      cached-factory:
+        specifier: ^0.0.2
+        version: 0.0.2
     devDependencies:
       '@prettier/sync':
         specifier: ^0.5.0
@@ -1355,6 +1359,10 @@ packages:
   cacheable-request@10.2.13:
     resolution: {integrity: sha512-3SD4rrMu1msNGEtNSt8Od6enwdo//U9s4ykmXfA2TD58kcLkCobtCDiby7kNyj7a/Q7lz/mAesAFI54rTdnvBA==}
     engines: {node: '>=14.16'}
+
+  cached-factory@0.0.2:
+    resolution: {integrity: sha512-4mhebGQ8YyvlDAX+zOHso5MezPi2pP11ZFE7vYhDIOJifsxEi7R5geB/nrLBYzQH5nwZ9kNsLAjM+WBj6osLDg==}
+    engines: {node: '>=18'}
 
   call-bind@1.0.2:
     resolution: {integrity: sha512-7O+FbCihrB5WGbFYesctwmTKae6rOiIzmz1icreWJ+0aA7LJfuqhEso2T9ncpcFtzMQtzXf2QGGueWJGTYsqrA==}
@@ -6147,6 +6155,8 @@ snapshots:
       mimic-response: 4.0.0
       normalize-url: 8.0.0
       responselike: 3.0.0
+
+  cached-factory@0.0.2: {}
 
   call-bind@1.0.2:
     dependencies:

--- a/src/getFunctionDeclarationFromCall.ts
+++ b/src/getFunctionDeclarationFromCall.ts
@@ -6,8 +6,17 @@ export function getFunctionDeclarationFromCall(
 	node: ts.CallExpression,
 	typeChecker: ts.TypeChecker,
 ) {
-	let declaration = typeChecker.getSymbolAtLocation(node.expression)
-		?.valueDeclaration;
+	let declaration: ts.Node | undefined = typeChecker.getSymbolAtLocation(
+		node.expression,
+	)?.valueDeclaration;
+
+	if (!declaration) {
+		return undefined;
+	}
+
+	if (ts.isVariableDeclaration(declaration)) {
+		declaration = declaration.initializer;
+	}
 
 	if (!declaration) {
 		return undefined;

--- a/src/isFunctionDeclarationWithBody.ts
+++ b/src/isFunctionDeclarationWithBody.ts
@@ -6,7 +6,9 @@ export const isFunctionWithBody = (
 	node: ts.Node,
 ): node is FunctionLikeWithBody => {
 	return (
-		(ts.isFunctionDeclaration(node) || ts.isFunctionExpression(node)) &&
+		(ts.isFunctionDeclaration(node) ||
+			ts.isFunctionExpression(node) ||
+			ts.isMethodDeclaration(node)) &&
 		!!node.body
 	);
 };

--- a/src/transformerProgram.ts
+++ b/src/transformerProgram.ts
@@ -1,7 +1,9 @@
+import { CachedFactory } from "cached-factory";
 import ts from "typescript";
 
 import { getFunctionDeclarationFromCall } from "./getFunctionDeclarationFromCall.js";
 import { transformToInline } from "./transformToInline.js";
+import { SmallFunctionLikeWithBody } from "./types.js";
 
 export const transformerProgram = (program: ts.Program) => {
 	const transformerFactory: ts.TransformerFactory<ts.SourceFile> = (
@@ -10,10 +12,31 @@ export const transformerProgram = (program: ts.Program) => {
 		return (sourceFile) => {
 			const typeChecker = program.getTypeChecker();
 
+			const functionDeclarationLengths = new CachedFactory(
+				(node: SmallFunctionLikeWithBody) =>
+					node.body.statements[0].getText(sourceFile).length - "return".length,
+			);
+
+			const getFunctionDeclarationForReplacement = (
+				node: ts.CallExpression,
+			) => {
+				const functionDeclaration = getFunctionDeclarationFromCall(
+					node,
+					typeChecker,
+				);
+
+				return (
+					functionDeclaration &&
+					functionDeclarationLengths.get(functionDeclaration) <=
+						node.getText(sourceFile).length &&
+					functionDeclaration
+				);
+			};
+
 			const visitor = (node: ts.Node): ts.Node => {
 				const functionDeclaration =
 					ts.isCallExpression(node) &&
-					getFunctionDeclarationFromCall(node, typeChecker);
+					getFunctionDeclarationForReplacement(node);
 
 				if (functionDeclaration) {
 					return transformToInline(node, functionDeclaration, context);


### PR DESCRIPTION
## PR Checklist

- [x] Addresses an existing open issue: fixes #3
- [x] That issue was marked as [`status: accepting prs`](https://github.com/JoshuaKGoldberg/ts-function-inliner/issues?q=is%3Aopen+is%3Aissue+label%3A%22status%3A+accepting+prs%22)
- [x] Steps in [CONTRIBUTING.md](https://github.com/JoshuaKGoldberg/ts-function-inliner/blob/main/.github/CONTRIBUTING.md) were taken

## Overview

Per the linked issue, this stops the transform from _increasing_ text size. Long functions will no longer be inlined.

Also adds support for function expressions in variables, as that came up in threshold testing.